### PR TITLE
[New Theme] | Emoji Replace

### DIFF
--- a/themes/Emoji Replace/README.md
+++ b/themes/Emoji Replace/README.md
@@ -1,0 +1,38 @@
+# Guilded Emoji Replace
+
+ReGuilded theme that replaces the default emoji pack with a custom one
+
+Emoji sheets and individual images are imported from [iamcal/emoji-data](https://github.com/iamcal/emoji-data/)
+
+Emoji packs can be switched out in the `theme.css` file - by default each pack uses 64x64 images for standalone emojis (used in chat, user statuses etc) and 32x32 emojis in the emoji picker (stored in one large "sheet", as a grid of emojis)
+
+# Available emoji packs
+- [Apple](#apple)
+- [Google](#google)
+- [Facebook](#facebook)
+## Apple
+![guilded-apple-emojis](https://user-images.githubusercontent.com/42148912/149998541-2ab0160b-4cff-4052-a68c-cf4a820a0376.png)\
+Emoji support: 3234/3237
+### Options
+High resolution emoji sheet (64x64) ~ 18 MB:
+```css
+:root { --sheet_emoji_size: 64 !important; --sheet: var(--sheet_high_resolution) !important; }
+```
+## Google
+![guilded-google-emojis](https://user-images.githubusercontent.com/42148912/149998716-a509cb9d-8502-4fcd-b875-c121c44aa22e.png)\
+Emoji support: 3237/3237
+### Options
+High resolution emoji sheet (64x64) ~ 12.3 MB:
+```css
+:root { --sheet_emoji_size: 64 !important; --sheet: var(--sheet_high_resolution) !important; }
+```
+## Facebook
+![guilded-facebook-emojis](https://user-images.githubusercontent.com/42148912/149998740-462753bd-a256-4304-aa1d-dba41b840232.png)\
+Emoji support: 3144/3237
+### Options
+High resolution emoji sheet (64x64) ~ 17.7 MB:
+```css
+:root { --sheet_emoji_size: 64 !important; --sheet: var(--sheet_high_resolution) !important; }
+```
+---
+### A more recent readme can be found [here](https://github.com/Davr1/Guilded-Emoji-Replace/)

--- a/themes/Emoji Replace/metadata.json
+++ b/themes/Emoji Replace/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "emoji-replace",
+  "name": "Emoji Replace",
+  "description": "Replaces the default Guilded emojis with a custom emoji pack",
+  "author": "VmMq9EQm",
+  "contributors": [],
+  "version": "v0.0.3.1",
+  "files": "theme.css"
+}

--- a/themes/Emoji Replace/theme.css
+++ b/themes/Emoji Replace/theme.css
@@ -1,0 +1,10 @@
+/* Switch out the emoji pack here ------------------------------------------------,      */
+/* Currently available packs and pack options can be found on the github page     |      */
+/* https://github.com/davr1/guilded-emoji-replace                                 v      */
+@import url("https://raw.githack.com/Davr1/Guilded-Emoji-Replace/master/emojis/Apple.css");
+/*                                                                       (Case Sensitive)*/
+
+/* Do not remove - this file is required for the theme to work */
+@import url("https://raw.githack.com/Davr1/Guilded-Emoji-Replace/master/common.css");
+
+/* (Optional) add pack options here */


### PR DESCRIPTION
Theme that replaces the default emoji pack with a custom one

Emoji packs can be switched out in the `theme.css` file - by default each pack uses 64x64 images for standalone emojis (used in chat, user statuses etc) and 32x32 emojis in the emoji picker (stored in one large "sheet", as a grid of emojis)

## Currently available emoji packs
### Apple
![guilded-apple-emojis](https://user-images.githubusercontent.com/42148912/149998541-2ab0160b-4cff-4052-a68c-cf4a820a0376.png)
### Google
![guilded-google-emojis](https://user-images.githubusercontent.com/42148912/149998716-a509cb9d-8502-4fcd-b875-c121c44aa22e.png)
### Facebook
![guilded-facebook-emojis](https://user-images.githubusercontent.com/42148912/149998740-462753bd-a256-4304-aa1d-dba41b840232.png)

Some packs also have modifiable options, for example you can switch to a high resolution sheet file using
```css
:root { --sheet_emoji_size: 64 !important; --sheet: var(--sheet_high_resolution) !important; }
```
More emoji packs will be added in the future